### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for integrating AI assistants with Printify's print-on-demand platform.
 
+<a href="https://glama.ai/mcp/servers/@TSavo/printify-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@TSavo/printify-mcp/badge" alt="Printify Server MCP server" />
+</a>
+
 ## Table of Contents
 
 - [Overview](#overview)


### PR DESCRIPTION
This PR adds a badge for the [Printify MCP Server](https://glama.ai/mcp/servers/@TSavo/printify-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@TSavo/printify-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@TSavo/printify-mcp/badge" alt="Printify Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a clickable image badge linking to the Printify MCP server page on glama.ai at the top of the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->